### PR TITLE
Fix multi download start too many task and the empty files not use in next time download

### DIFF
--- a/YoutubeDownloader/ViewModels/Components/DownloadViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Components/DownloadViewModel.cs
@@ -37,8 +37,28 @@ namespace YoutubeDownloader.ViewModels.Components
         public IProgressOperation ProgressOperation { get; private set; }
 
         public bool IsActive { get; private set; }
+        /// <summary>
+        ///  Event raise when download finished
+        /// </summary>
+        public event EventHandler<EventArgs> Finished;
 
-        public bool IsSuccessful { get; private set; }
+        bool _isSuccessful = false;
+        public bool IsSuccessful
+        {
+            get
+            {
+                return _isSuccessful;
+            }
+            private set
+            {
+                _isSuccessful = value;
+                if (value)
+                {
+                    if (Finished != null)
+                        this.Finished(this, new EventArgs());
+                }
+            }
+        }
 
         public bool IsCanceled { get; private set; }
 

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
@@ -73,16 +73,19 @@ namespace YoutubeDownloader.ViewModels.Dialogs
                 // If file exists - either skip it or generate a unique file path, depending on user settings
                 if (File.Exists(filePath))
                 {
-                    if (_settingsService.ShouldSkipExistingFiles && new FileInfo(filePath).Length > 0)
+                    var fi = new FileInfo(filePath);
+                    if (_settingsService.ShouldSkipExistingFiles && fi.Length > 0)
                         continue;
-
-                    filePath = FileEx.MakeUniqueFilePath(filePath);
+                    //if file length is 0,  don't need to create new one
+                    if (fi.Length != 0)
+                        filePath = FileEx.MakeUniqueFilePath(filePath);
                 }
-
-                // Create empty file to "lock in" the file path
-                FileEx.CreateDirectoriesForFile(filePath);
-                FileEx.CreateEmptyFile(filePath);
-
+                else//there is some empty file exists,so only need run this code when file not exists
+                {
+                    // Create empty file to "lock in" the file path
+                    FileEx.CreateDirectoriesForFile(filePath);
+                    FileEx.CreateEmptyFile(filePath);
+                }
                 // Create download view model
                 var download = _viewModelFactory.CreateDownloadViewModel(video, filePath, SelectedFormat);
 


### PR DESCRIPTION
1.fix that create too many empty files
2.try fix the multi download fails when task more than 100, now use the event to start a new task

I am a newbie here, it is my first-time to use Github. I am learning C# by myself, and not good at it. I try to add code fix my problem I post in Issues #92. Please forgive me if this brings you trouble.

I am sorry, this change has some bugs. If a task fails, it can't start a new task. If a task was canceled, I also can't start  a new one.