### PR TITLE
Add option to exclude container formats from format selection combo box when downloading a video

### DIFF
--- a/YoutubeDownloader/Services/DownloadService.cs
+++ b/YoutubeDownloader/Services/DownloadService.cs
@@ -82,6 +82,7 @@ namespace YoutubeDownloader.Services
             // Video+audio options
             var videoStreams = streamManifest
                 .GetVideo()
+                .Where(v => !_settingsService.ExcludedContainerFormats.Contains(v.Container.Name))
                 .OrderByDescending(v => v.VideoQuality)
                 .ThenByDescending(v => v.Framerate);
 
@@ -119,8 +120,11 @@ namespace YoutubeDownloader.Services
 
             if (bestAudioOnlyStreamInfo != null)
             {
-                options.Add(new DownloadOption("mp3", "Audio", bestAudioOnlyStreamInfo));
-                options.Add(new DownloadOption("ogg", "Audio", bestAudioOnlyStreamInfo));
+                if (!_settingsService.ExcludedContainerFormats.Contains("mp3"))
+                    options.Add(new DownloadOption("mp3", "Audio", bestAudioOnlyStreamInfo));
+
+                if (!_settingsService.ExcludedContainerFormats.Contains("ogg"))
+                    options.Add(new DownloadOption("ogg", "Audio", bestAudioOnlyStreamInfo));
             }
 
             return options.ToArray();

--- a/YoutubeDownloader/Services/SettingsService.cs
+++ b/YoutubeDownloader/Services/SettingsService.cs
@@ -1,4 +1,5 @@
-﻿using Tyrrrz.Settings;
+﻿using System.Collections.Generic;
+using Tyrrrz.Settings;
 using YoutubeDownloader.Internal;
 
 namespace YoutubeDownloader.Services
@@ -10,6 +11,8 @@ namespace YoutubeDownloader.Services
         public int MaxConcurrentDownloadCount { get; set; } = 2;
 
         public string FileNameTemplate { get; set; } = FileNameGenerator.DefaultTemplate;
+
+        public IList<string> ExcludedContainerFormats { get; set; } = new List<string>();
 
         public bool ShouldInjectTags { get; set; } = true;
 

--- a/YoutubeDownloader/ViewModels/Dialogs/SettingsViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/SettingsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Tyrrrz.Extensions;
+﻿using System.Linq;
+using Tyrrrz.Extensions;
 using YoutubeDownloader.Services;
 using YoutubeDownloader.ViewModels.Framework;
 
@@ -24,6 +25,12 @@ namespace YoutubeDownloader.ViewModels.Dialogs
         {
             get => _settingsService.FileNameTemplate;
             set => _settingsService.FileNameTemplate = value;
+        }
+
+        public string ExcludedContainerFormats
+        {
+            get => _settingsService.ExcludedContainerFormats != null ? string.Join(',', _settingsService.ExcludedContainerFormats) : string.Empty;
+            set => _settingsService.ExcludedContainerFormats = value.Split(',').Select(x => x.Trim()).Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
         }
 
         public bool ShouldInjectTags

--- a/YoutubeDownloader/Views/Dialogs/SettingsView.xaml
+++ b/YoutubeDownloader/Views/Dialogs/SettingsView.xaml
@@ -63,6 +63,22 @@
             </TextBox.ToolTip>
         </TextBox>
 
+        <!--  Excluded container formats  -->
+        <TextBox
+            Margin="16,8"
+            materialDesign:HintAssist.Hint="Excluded container formats"
+            materialDesign:HintAssist.IsFloating="True"
+            Text="{Binding ExcludedContainerFormats}">
+            <TextBox.ToolTip>
+                <TextBlock>
+                    <Run Text="Comma separated list of container formats excluded from format list when downloading a video" />
+                    <LineBreak />
+                    <LineBreak />
+                    <Run Text="Ex: webm,ogg" />
+                </TextBlock>
+            </TextBox.ToolTip>
+        </TextBox>
+
         <!--  Auto-updates  -->
         <DockPanel Background="Transparent" LastChildFill="False">
             <DockPanel.ToolTip>


### PR DESCRIPTION
I added an option to Settings to define excluded container formats as requested by #81. Some screenshots are below.

When we first open the Settings dialog:

![image](https://user-images.githubusercontent.com/2426207/95681319-c7100980-0be7-11eb-853b-88b4c1ab59d9.png)

When we define some formats to exclude:

![image](https://user-images.githubusercontent.com/2426207/95681335-e6a73200-0be7-11eb-86dc-66edfb3e35b0.png)

We also have tool tip:

![image](https://user-images.githubusercontent.com/2426207/95681396-46054200-0be8-11eb-84f1-b30154b5c0af.png)

When downloading a file after defined some container formats to exclude:

![image](https://user-images.githubusercontent.com/2426207/95681360-0cccd200-0be8-11eb-8a80-3ef05f38bede.png)
