### PR TITLE
Use latest dotnet version in GitHub workflows

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: '3.1.x'
 
     - name: Build & publish
       run: dotnet publish YoutubeDownloader/ -o YoutubeDownloader/bin/Publish --configuration Release

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: '3.1.x'
 
     - name: Build & publish
       run: dotnet publish YoutubeDownloader/ -o YoutubeDownloader/bin/Publish --configuration Release


### PR DESCRIPTION
Use the latest dotnet version in GitHub workflows, instead of a hardcoded one, that lacks a bunch of security updates: https://dotnet.microsoft.com/download/dotnet-core/3.1