### PR TITLE
Ensure file size is not 0 before skipping when ShouldSkipExistingFiles is enabled

### DIFF
--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
@@ -94,7 +94,7 @@ namespace YoutubeDownloader.ViewModels.Dialogs
                 var filePath = Path.Combine(dirPath, fileName);
 
                 // If file exists or is no empty - either skip it or generate a unique file path, depending on user settings
-                FileInfo fileInfo = new FileInfo(fileName);
+                var fileInfo = new FileInfo(fileName);
 
                 if (fileInfo.Exists && fileInfo.Length > 0)
                 {

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
@@ -93,8 +93,10 @@ namespace YoutubeDownloader.ViewModels.Dialogs
 
                 var filePath = Path.Combine(dirPath, fileName);
 
-                // If file exists - either skip it or generate a unique file path, depending on user settings
-                if (File.Exists(filePath))
+                // If file exists or is no empty - either skip it or generate a unique file path, depending on user settings
+                FileInfo fileInfo = new FileInfo(fileName);
+
+                if (fileInfo.Exists && fileInfo.Length > 0)
                 {
                     if (_settingsService.ShouldSkipExistingFiles)
                         continue;


### PR DESCRIPTION
I often had the problem that files with a size of 0 MB were left after an aborted download. This patch is intended to fix this.