### PR TITLE
Update YoutubeExplode to v6.0-alpha2

### DIFF
--- a/YoutubeDownloader/Behaviors/VideoMultiSelectionListBoxBehavior.cs
+++ b/YoutubeDownloader/Behaviors/VideoMultiSelectionListBoxBehavior.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Xaml.Behaviors;
-using YoutubeExplode.Videos;
+using YoutubeDownloader.Models;
 
 namespace YoutubeDownloader.Behaviors
 {
@@ -59,7 +59,7 @@ namespace YoutubeDownloader.Behaviors
             if (_viewHandled) return;
             if (AssociatedObject.Items.SourceCollection is null) return;
 
-            SelectedItems = AssociatedObject.SelectedItems.Cast<Video>().ToArray();
+            SelectedItems = AssociatedObject.SelectedItems.Cast<VideoInformation>().ToArray();
         }
 
         // Re-select items when the set of items changes

--- a/YoutubeDownloader/Internal/FileNameGenerator.cs
+++ b/YoutubeDownloader/Internal/FileNameGenerator.cs
@@ -1,4 +1,4 @@
-﻿using YoutubeExplode.Videos;
+﻿using YoutubeDownloader.Models;
 
 namespace YoutubeDownloader.Internal
 {
@@ -16,7 +16,7 @@ namespace YoutubeDownloader.Internal
 
         public static string GenerateFileName(
             string template,
-            Video video,
+            VideoInformation video,
             string format,
             string? number = null)
         {
@@ -25,7 +25,7 @@ namespace YoutubeDownloader.Internal
             result = result.Replace(NumberToken, !string.IsNullOrWhiteSpace(number) ? $"[{number}]" : "");
             result = result.Replace(TitleToken, video.Title);
             result = result.Replace(AuthorToken, video.Author);
-            result = result.Replace(UploadDateToken, video.UploadDate.ToString("yyyy-MM-dd"));
+            result = result.Replace(UploadDateToken, video.UploadDate?.ToString("yyyy-MM-dd"));
 
             result = result.Trim();
 

--- a/YoutubeDownloader/Models/ExecutedQuery.cs
+++ b/YoutubeDownloader/Models/ExecutedQuery.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using YoutubeExplode.Videos;
 
 namespace YoutubeDownloader.Models
 {
@@ -9,9 +8,9 @@ namespace YoutubeDownloader.Models
 
         public string Title { get; }
 
-        public IReadOnlyList<Video> Videos { get; }
+        public IReadOnlyList<VideoInformation> Videos { get; }
 
-        public ExecutedQuery(Query query, string title, IReadOnlyList<Video> videos)
+        public ExecutedQuery(Query query, string title, IReadOnlyList<VideoInformation> videos)
         {
             Query = query;
             Title = title;

--- a/YoutubeDownloader/Models/VideoInformation.cs
+++ b/YoutubeDownloader/Models/VideoInformation.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YoutubeExplode.Common;
+using YoutubeExplode.Playlists;
+using YoutubeExplode.Videos;
+
+namespace YoutubeDownloader.Models
+{
+    public class VideoInformation
+    {
+        private VideoInformation(VideoId id, string title, string author, DateTimeOffset? uploadDate, TimeSpan duration,
+            ThumbnailSet thumbnails)
+        {
+            Id = id;
+            Title = title;
+            Author = author;
+            UploadDate = uploadDate;
+            Duration = duration;
+            Thumbnails = thumbnails;
+        }
+
+        /// <summary>
+        ///     Video ID.
+        /// </summary>
+        public VideoId Id { get; }
+
+        /// <summary>
+        ///     Video title.
+        /// </summary>
+        public string Title { get; }
+
+        /// <summary>
+        ///     Video author.
+        /// </summary>
+        public string Author { get; }
+
+        /// <summary>
+        ///     Video upload date.
+        /// </summary>
+        public DateTimeOffset? UploadDate { get; }
+
+        /// <summary>
+        ///     Duration of the video.
+        /// </summary>
+        public TimeSpan Duration { get; }
+
+        /// <summary>
+        ///     Available thumbnails for this video.
+        /// </summary>
+        public ThumbnailSet Thumbnails { get; }
+
+        public static IReadOnlyList<VideoInformation> VideoInformationAsList(Video video)
+        {
+            return new[]
+            {
+                new VideoInformation(video.Id, video.Title, video.Author, video.UploadDate, video.Duration,
+                    video.Thumbnails)
+            };
+        }
+
+        public static IReadOnlyList<VideoInformation> VideoInformationAsList(IEnumerable<PlaylistVideo> videos)
+        {
+            return videos.Select(video => new VideoInformation(video.Id, video.Title, video.Author, null, 
+                video.Duration, video.Thumbnails)).ToList();
+        }
+    }
+}

--- a/YoutubeDownloader/Services/QueryService.cs
+++ b/YoutubeDownloader/Services/QueryService.cs
@@ -62,7 +62,7 @@ namespace YoutubeDownloader.Services
             {
                 var video = await _youtube.Videos.GetAsync(query.Value);
 
-                return new ExecutedQuery(query, video.Title, new[] {video});
+                return new ExecutedQuery(query, video.Title, VideoInformation.VideoInformationAsList(video));
             }
 
             // Playlist
@@ -71,7 +71,7 @@ namespace YoutubeDownloader.Services
                 var playlist = await _youtube.Playlists.GetAsync(query.Value);
                 var videos = await _youtube.Playlists.GetVideosAsync(query.Value).BufferAsync();
 
-                return new ExecutedQuery(query, playlist.Title, videos);
+                return new ExecutedQuery(query, playlist.Title, VideoInformation.VideoInformationAsList(videos));
             }
 
             // Channel
@@ -80,7 +80,7 @@ namespace YoutubeDownloader.Services
                 var channel = await _youtube.Channels.GetAsync(query.Value);
                 var videos = await _youtube.Channels.GetUploadsAsync(query.Value).BufferAsync();
 
-                return new ExecutedQuery(query, $"Channel uploads: {channel.Title}", videos);
+                return new ExecutedQuery(query, $"Channel uploads: {channel.Title}", VideoInformation.VideoInformationAsList(videos));
             }
 
             // User
@@ -89,7 +89,7 @@ namespace YoutubeDownloader.Services
                 var channel = await _youtube.Channels.GetByUserAsync(query.Value);
                 var videos = await _youtube.Channels.GetUploadsAsync(channel.Id).BufferAsync();
 
-                return new ExecutedQuery(query, $"Channel uploads: {channel.Title}", videos);
+                return new ExecutedQuery(query, $"Channel uploads: {channel.Title}", VideoInformation.VideoInformationAsList(videos));
             }
 
             // Search
@@ -97,7 +97,7 @@ namespace YoutubeDownloader.Services
             {
                 var videos = await _youtube.Search.GetVideosAsync(query.Value).BufferAsync(200);
 
-                return new ExecutedQuery(query, $"Search: {query.Value}", videos);
+                return new ExecutedQuery(query, $"Search: {query.Value}", VideoInformation.VideoInformationAsList(videos));
             }
 
             throw new ArgumentException($"Could not parse query '{query}'.", nameof(query));

--- a/YoutubeDownloader/Services/TaggingService.cs
+++ b/YoutubeDownloader/Services/TaggingService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using TagLib;
 using TagLib.Mpeg4;
-using YoutubeExplode.Videos;
+using YoutubeDownloader.Models;
 using File = TagLib.File;
 
 namespace YoutubeDownloader.Services
@@ -78,7 +78,7 @@ namespace YoutubeDownloader.Services
         }
 
         private async Task<IPicture?> TryGetPictureAsync(
-            Video video,
+            VideoInformation video,
             CancellationToken cancellationToken = default)
         {
             try
@@ -144,7 +144,7 @@ namespace YoutubeDownloader.Services
         }
 
         private async Task InjectVideoTagsAsync(
-            Video video,
+            VideoInformation video,
             string filePath,
             CancellationToken cancellationToken = default)
         {
@@ -153,7 +153,7 @@ namespace YoutubeDownloader.Services
             var file = File.Create(filePath);
 
             var appleTag = (AppleTag) file.GetTag(TagTypes.Apple);
-            appleTag.SetDashBox("Upload Date", "    Upload Date", video.UploadDate.ToString("yyyy-MM-dd"));
+            appleTag.SetDashBox("Upload Date", "    Upload Date", video.UploadDate?.ToString("yyyy-MM-dd"));
             appleTag.SetDashBox("Channel", "    Channel", video.Author);
 
             file.Tag.Pictures = picture is not null
@@ -164,7 +164,7 @@ namespace YoutubeDownloader.Services
         }
 
         private async Task InjectAudioTagsAsync(
-            Video video,
+            VideoInformation video,
             string filePath,
             CancellationToken cancellationToken = default)
         {
@@ -193,7 +193,7 @@ namespace YoutubeDownloader.Services
         }
 
         public async Task InjectTagsAsync(
-            Video video,
+            VideoInformation video,
             string format,
             string filePath,
             CancellationToken cancellationToken = default)

--- a/YoutubeDownloader/ViewModels/Components/DownloadViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Components/DownloadViewModel.cs
@@ -10,7 +10,6 @@ using YoutubeDownloader.Services;
 using YoutubeDownloader.ViewModels.Dialogs;
 using YoutubeDownloader.ViewModels.Framework;
 using YoutubeExplode.Exceptions;
-using YoutubeExplode.Videos;
 
 namespace YoutubeDownloader.ViewModels.Components
 {
@@ -24,7 +23,7 @@ namespace YoutubeDownloader.ViewModels.Components
 
         private CancellationTokenSource? _cancellationTokenSource;
 
-        public Video Video { get; set; } = default!;
+        public VideoInformation Video { get; set; } = default!;
 
         public string FilePath { get; set; } = default!;
 
@@ -195,7 +194,7 @@ namespace YoutubeDownloader.ViewModels.Components
     {
         public static DownloadViewModel CreateDownloadViewModel(
             this IViewModelFactory factory,
-            Video video,
+            VideoInformation video,
             string filePath,
             string format,
             VideoDownloadOption videoOption,
@@ -214,7 +213,7 @@ namespace YoutubeDownloader.ViewModels.Components
 
         public static DownloadViewModel CreateDownloadViewModel(
             this IViewModelFactory factory,
-            Video video,
+            VideoInformation video,
             string filePath,
             string format,
             VideoQualityPreference qualityPreference)

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
@@ -8,7 +8,6 @@ using YoutubeDownloader.Models;
 using YoutubeDownloader.Services;
 using YoutubeDownloader.ViewModels.Components;
 using YoutubeDownloader.ViewModels.Framework;
-using YoutubeExplode.Videos;
 
 namespace YoutubeDownloader.ViewModels.Dialogs
 {
@@ -20,9 +19,9 @@ namespace YoutubeDownloader.ViewModels.Dialogs
 
         public string Title { get; set; } = default!;
 
-        public IReadOnlyList<Video> AvailableVideos { get; set; } = Array.Empty<Video>();
+        public IReadOnlyList<VideoInformation> AvailableVideos { get; set; } = Array.Empty<VideoInformation>();
 
-        public IReadOnlyList<Video> SelectedVideos { get; set; } = Array.Empty<Video>();
+        public IReadOnlyList<VideoInformation> SelectedVideos { get; set; } = Array.Empty<VideoInformation>();
 
         public IReadOnlyList<string> AvailableFormats { get; set; } = new[] { "mp4", "mp3", "ogg" };
 
@@ -131,7 +130,7 @@ namespace YoutubeDownloader.ViewModels.Dialogs
         public static DownloadMultipleSetupViewModel CreateDownloadMultipleSetupViewModel(
             this IViewModelFactory factory,
             string title,
-            IReadOnlyList<Video> availableVideos)
+            IReadOnlyList<VideoInformation> availableVideos)
         {
             var viewModel = factory.CreateDownloadMultipleSetupViewModel();
 

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadSingleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadSingleSetupViewModel.cs
@@ -7,7 +7,6 @@ using YoutubeDownloader.Models;
 using YoutubeDownloader.Services;
 using YoutubeDownloader.ViewModels.Components;
 using YoutubeDownloader.ViewModels.Framework;
-using YoutubeExplode.Videos;
 
 namespace YoutubeDownloader.ViewModels.Dialogs
 {
@@ -19,7 +18,7 @@ namespace YoutubeDownloader.ViewModels.Dialogs
 
         public string Title { get; set; } = default!;
 
-        public Video Video { get; set; } = default!;
+        public VideoInformation Video { get; set; } = default!;
 
         public IReadOnlyList<VideoDownloadOption> AvailableVideoOptions { get; set; } =
             Array.Empty<VideoDownloadOption>();
@@ -104,7 +103,7 @@ namespace YoutubeDownloader.ViewModels.Dialogs
         public static DownloadSingleSetupViewModel CreateDownloadSingleSetupViewModel(
             this IViewModelFactory factory,
             string title,
-            Video video,
+            VideoInformation video,
             IReadOnlyList<VideoDownloadOption> availableDownloadOptions,
             IReadOnlyList<SubtitleDownloadOption> availableSubtitleOptions)
         {

--- a/YoutubeDownloader/YoutubeDownloader.csproj
+++ b/YoutubeDownloader/YoutubeDownloader.csproj
@@ -15,16 +15,16 @@
     <PackageReference Include="MaterialDesignColors" Version="1.2.2" />
     <PackageReference Include="MaterialDesignThemes" Version="3.0.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Onova" Version="2.6.2" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
-    <PackageReference Include="Stylet" Version="1.3.5" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
     <PackageReference Include="taglib" Version="2.1.0" />
     <PackageReference Include="Tyrrrz.Extensions" Version="1.6.5" />
     <PackageReference Include="Tyrrrz.Settings" Version="1.3.4" />
     <PackageReference Include="YoutubeExplode" Version="5.1.9" />
     <PackageReference Include="YoutubeExplode.Converter" Version="2.0.2" />
-    <PackageReference Include="PropertyChanged.Fody" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="PropertyChanged.Fody" Version="4.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="Format XAML" AfterTargets="BeforeBuild">

--- a/YoutubeDownloader/YoutubeDownloader.csproj
+++ b/YoutubeDownloader/YoutubeDownloader.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="taglib" Version="2.1.0" />
     <PackageReference Include="Tyrrrz.Extensions" Version="1.6.5" />
     <PackageReference Include="Tyrrrz.Settings" Version="1.3.4" />
-    <PackageReference Include="YoutubeExplode" Version="5.1.9" />
+    <PackageReference Include="YoutubeExplode" Version="6.0.0-alpha2" />
     <PackageReference Include="YoutubeExplode.Converter" Version="2.0.2" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.0.0" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
I updated the downloader to the latest YoutubeExplode-Alpha. This is my suggestion for solving the new YoutubeExplode library structure. Perhaps you can already provide this PR in a other branch and / or publish the branch as a pre-release. 