### PR TITLE
Fix warnings in GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,8 +51,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: YoutubeDownloader.zip
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref }}
           body: |
             [Changelog](https://github.com/Tyrrrz/YoutubeDownloader/blob/master/Changelog.md)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         run: Compress-Archive -Path YoutubeDownloader/* -DestinationPath YoutubeDownloader.zip -Force
         shell: pwsh
 
-      - name: Upload to Release
+      - name: Create release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,28 +45,16 @@ jobs:
         run: Compress-Archive -Path YoutubeDownloader/* -DestinationPath YoutubeDownloader.zip -Force
         shell: pwsh
 
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          files: YoutubeDownloader.zip
+          name: ${{ github.ref_name }}
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           body: |
             [Changelog](https://github.com/Tyrrrz/YoutubeDownloader/blob/master/Changelog.md)
-          draft: false
-          prerelease: false
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: YoutubeDownloader.zip
-          asset_path: YoutubeDownloader.zip
-          asset_content_type: application/zip
 
   notify:
     needs: deploy


### PR DESCRIPTION
Fixes these warnings

* Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/create-release@v1, actions/upload-release-asset@v1

* The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Sakshi Aggarwal <81718060+sakshiagrwal@users.noreply.github.com>

<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
Closes #ISSUE_NUMBER
