### PR TITLE
Attempt to clean-up WV2 data folder on window close

### DIFF
--- a/YoutubeDownloader/Views/Dialogs/AuthSetupView.xaml
+++ b/YoutubeDownloader/Views/Dialogs/AuthSetupView.xaml
@@ -76,7 +76,6 @@
                     Loaded="WebBrowser_OnLoaded"
                     NavigationCompleted="WebBrowser_OnNavigationCompleted"
                     NavigationStarting="WebBrowser_OnNavigationStarting"
-                    Unloaded="WebBrowser_OnUnloaded"
                     Visibility="{Binding IsAuthenticated, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
                     <wpf:WebView2.CreationProperties>
                         <wpf:CoreWebView2CreationProperties IsInPrivateModeEnabled="True" />
@@ -94,6 +93,7 @@
             Content="CLOSE"
             IsCancel="True"
             IsDefault="True"
-            Style="{DynamicResource MaterialDesignOutlinedButton}" />
+            Style="{DynamicResource MaterialDesignOutlinedButton}"
+            Click="Button_Click" />
     </Grid>
 </UserControl>

--- a/YoutubeDownloader/Views/Dialogs/AuthSetupView.xaml.cs
+++ b/YoutubeDownloader/Views/Dialogs/AuthSetupView.xaml.cs
@@ -10,6 +10,7 @@ namespace YoutubeDownloader.Views.Dialogs;
 public partial class AuthSetupView
 {
     private const string HomePageUrl = "https://www.youtube.com";
+    private string UDF = "";
     private static readonly string LoginPageUrl =
         $"https://accounts.google.com/ServiceLogin?continue={WebUtility.UrlEncode(HomePageUrl)}";
 
@@ -43,6 +44,7 @@ public partial class AuthSetupView
         WebBrowser.CoreWebView2.Settings.IsPasswordAutosaveEnabled = false;
         WebBrowser.CoreWebView2.Settings.IsStatusBarEnabled = false;
         WebBrowser.CoreWebView2.Settings.IsSwipeNavigationEnabled = false;
+        WebBrowser.CoreWebView2.Environment.BrowserProcessExited += BrowserExitComplete;
     }
 
     private void WebBrowser_OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs args)
@@ -65,11 +67,19 @@ public partial class AuthSetupView
         }
     }
 
-    private async void WebBrowser_OnUnloaded(object sender, RoutedEventArgs args)
+    private async void Button_Click(object sender, RoutedEventArgs e)
     {
-        // This will most likely not work because WebView2 would still be running at this point,
-        // and there doesn't seem to be any way to shut it down using the .NET API.
-        if (WebBrowser.CoreWebView2?.Profile is not null)
+        if (WebBrowser.CoreWebView2 is not null)
+        {
+            UDF = WebBrowser.CoreWebView2.Environment.UserDataFolder;
             await WebBrowser.CoreWebView2.Profile.ClearBrowsingDataAsync();
+        }
+        WebBrowser.Dispose();
+    }
+
+    private void BrowserExitComplete(object? sender, CoreWebView2BrowserProcessExitedEventArgs e)
+    {
+        if (UDF != "" && System.IO.Directory.Exists(UDF))
+            System.IO.Directory.Delete(UDF, true);
     }
 }


### PR DESCRIPTION
Taking a quick stab at the direction of cleaning up WV2 data. This will clear the browsing data when the user closes the auth window, trigger a dispose of the control, then delete the entire user data folder once the WV2 processes finish getting shutdown.

I'm not the best WPF developer, so I'm not sure doing this on `Click` is actually correct, but figured sharing something is better than nothing 😊. I was also able to hit some mild race condition that left the data folder by very quickly opening and closing the auth window. That's partially why there's the `ClearBrowsingData` call - the deleting of the UDF is "best effort" but `ClearBrowsingData` has a stronger guarantee that data will be deleted, just not all of it.