### PR TITLE
Fix order in applying `$num` and `$numc` tokens

### DIFF
--- a/YoutubeDownloader.Core/Downloading/FileNameTemplate.cs
+++ b/YoutubeDownloader.Core/Downloading/FileNameTemplate.cs
@@ -14,8 +14,8 @@ public class FileNameTemplate
     ) =>
         PathEx.EscapeFileName(
             template
-                .Replace("$num", number is not null ? $"[{number}]" : "")
                 .Replace("$numc", number ?? "")
+                .Replace("$num", number is not null ? $"[{number}]" : "")
                 .Replace("$id", video.Id)
                 .Replace("$title", video.Title)
                 .Replace("$author", video.Author.ChannelTitle)


### PR DESCRIPTION
<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #377 

The order broke the parameter.

``$num`` worked correctly but when it reached ``$numc`` it looked like this:

[01]c
[02]c
[03]c
[04]c
[05]c
...

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
