### PR TITLE
Use a 3-way theme switcher instead of a 2-way switcher

### DIFF
--- a/YoutubeDownloader/App.axaml
+++ b/YoutubeDownloader/App.axaml
@@ -7,19 +7,33 @@
     xmlns:materialAssists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
     xmlns:materialControls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
     xmlns:materialIcons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
-    xmlns:materialStyles="clr-namespace:Material.Styles.Themes;assembly=Material.Styles">
+    xmlns:materialStyles="clr-namespace:Material.Styles.Themes;assembly=Material.Styles"
+    ActualThemeVariantChanged="Application_OnActualThemeVariantChanged">
     <Application.DataTemplates>
         <framework:ViewManager />
     </Application.DataTemplates>
 
     <Application.Styles>
-        <materialStyles:MaterialTheme />
+        <!--  Hack: this brush is missing on initialization for some reason  -->
+        <Style>
+            <Style.Resources>
+                <ResourceDictionary>
+                    <SolidColorBrush x:Key="MaterialPaperBrush" Color="#FF303030" />
+                </ResourceDictionary>
+            </Style.Resources>
+        </Style>
+
+        <materialStyles:MaterialThemeBase />
         <materialIcons:MaterialIconStyles />
         <dialogHostAvalonia:DialogHostStyles />
 
         <!--  Combo box  -->
         <Style Selector="ComboBox">
             <Setter Property="FontSize" Value="14" />
+
+            <Style Selector="^ /template/ Panel#PART_RootPanel">
+                <Setter Property="Height" Value="22" />
+            </Style>
 
             <Style Selector="^ /template/ ToggleButton">
                 <Style Selector="^:checked, ^:unchecked">

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -10,17 +10,23 @@ using Material.Styles.Themes;
 using Microsoft.Extensions.DependencyInjection;
 using YoutubeDownloader.Framework;
 using YoutubeDownloader.Services;
+using YoutubeDownloader.Utils;
+using YoutubeDownloader.Utils.Extensions;
 using YoutubeDownloader.ViewModels;
 using YoutubeDownloader.ViewModels.Components;
 using YoutubeDownloader.ViewModels.Dialogs;
 using YoutubeDownloader.Views;
+using ThemeVariant = Avalonia.Styling.ThemeVariant;
 
 namespace YoutubeDownloader;
 
-public partial class App : Application, IDisposable
+public class App : Application, IDisposable
 {
     private readonly ServiceProvider _services;
+    private readonly SettingsService _settingsService;
     private readonly MainViewModel _mainViewModel;
+
+    private readonly DisposableCollector _eventRoot = new();
 
     public App()
     {
@@ -47,26 +53,41 @@ public partial class App : Application, IDisposable
         services.AddTransient<SettingsViewModel>();
 
         _services = services.BuildServiceProvider(true);
+        _settingsService = _services.GetRequiredService<SettingsService>();
         _mainViewModel = _services.GetRequiredService<ViewModelManager>().CreateMainViewModel();
+
+        // Re-initialize the theme when the user changes it
+        _eventRoot.Add(
+            _settingsService.WatchProperty(
+                o => o.Theme,
+                () =>
+                {
+                    RequestedThemeVariant = _settingsService.Theme switch
+                    {
+                        Framework.ThemeVariant.System => ThemeVariant.Default,
+                        Framework.ThemeVariant.Light => ThemeVariant.Light,
+                        Framework.ThemeVariant.Dark => ThemeVariant.Dark,
+                        _
+                            => throw new InvalidOperationException(
+                                $"Unknown theme '{_settingsService.Theme}'."
+                            )
+                    };
+
+                    InitializeTheme();
+                },
+                false
+            )
+        );
     }
 
     public override void Initialize()
     {
+        base.Initialize();
+
         // Increase maximum concurrent connections
         ServicePointManager.DefaultConnectionLimit = 20;
 
         AvaloniaXamlLoader.Load(this);
-    }
-
-    public override void OnFrameworkInitializationCompleted()
-    {
-        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
-            desktop.MainWindow = new MainView { DataContext = _mainViewModel };
-
-        base.OnFrameworkInitializationCompleted();
-
-        // Set custom theme colors
-        SetDefaultTheme();
     }
 
     public override void RegisterServices()
@@ -76,54 +97,69 @@ public partial class App : Application, IDisposable
         AvaloniaWebViewBuilder.Initialize(config => config.IsInPrivateModeEnabled = true);
     }
 
-    public void Dispose() => _services.Dispose();
-}
-
-public partial class App
-{
-    public static void SetLightTheme()
+    private void InitializeTheme()
     {
-        if (Current is null)
-            return;
+        var requestedTheme = RequestedThemeVariant ?? ThemeVariant.Default;
 
-        Current.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
-            Theme.Light,
-            Color.Parse("#343838"),
-            Color.Parse("#F9A825")
-        );
+        var actualTheme = requestedTheme.Key switch
+        {
+            "Default" => PlatformSettings?.GetColorValues().ThemeVariant,
+            "Light" => PlatformThemeVariant.Light,
+            "Dark" => PlatformThemeVariant.Dark,
+            _
+                => throw new ArgumentOutOfRangeException(
+                    nameof(requestedTheme),
+                    $"Unknown theme '{requestedTheme}'."
+                )
+        };
 
-        Current.Resources["SuccessBrush"] = new SolidColorBrush(Colors.DarkGreen);
-        Current.Resources["CanceledBrush"] = new SolidColorBrush(Colors.DarkOrange);
-        Current.Resources["FailedBrush"] = new SolidColorBrush(Colors.DarkRed);
-    }
+        if (actualTheme == PlatformThemeVariant.Light)
+        {
+            this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
+                Theme.Light,
+                Color.Parse("#343838"),
+                Color.Parse("#F9A825")
+            );
 
-    public static void SetDarkTheme()
-    {
-        if (Current is null)
-            return;
-
-        Current.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
-            Theme.Dark,
-            Color.Parse("#E8E8E8"),
-            Color.Parse("#F9A825")
-        );
-
-        Current.Resources["SuccessBrush"] = new SolidColorBrush(Colors.LightGreen);
-        Current.Resources["CanceledBrush"] = new SolidColorBrush(Colors.Orange);
-        Current.Resources["FailedBrush"] = new SolidColorBrush(Colors.OrangeRed);
-    }
-
-    public static void SetDefaultTheme()
-    {
-        if (Current is null)
-            return;
-
-        var isDarkModeEnabledByDefault =
-            Current.PlatformSettings?.GetColorValues().ThemeVariant == PlatformThemeVariant.Dark;
-
-        if (isDarkModeEnabledByDefault)
-            SetDarkTheme();
+            Resources["SuccessBrush"] = new SolidColorBrush(Colors.DarkGreen);
+            Resources["CanceledBrush"] = new SolidColorBrush(Colors.DarkOrange);
+            Resources["FailedBrush"] = new SolidColorBrush(Colors.DarkRed);
+        }
         else
-            SetLightTheme();
+        {
+            this.LocateMaterialTheme<MaterialThemeBase>().CurrentTheme = Theme.Create(
+                Theme.Dark,
+                Color.Parse("#E8E8E8"),
+                Color.Parse("#F9A825")
+            );
+
+            Resources["SuccessBrush"] = new SolidColorBrush(Colors.LightGreen);
+            Resources["CanceledBrush"] = new SolidColorBrush(Colors.Orange);
+            Resources["FailedBrush"] = new SolidColorBrush(Colors.OrangeRed);
+        }
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            desktop.MainWindow = new MainView { DataContext = _mainViewModel };
+
+        base.OnFrameworkInitializationCompleted();
+
+        // Set up custom theme colors
+        InitializeTheme();
+
+        // Load settings
+        _settingsService.Load();
+    }
+
+    private void Application_OnActualThemeVariantChanged(object? sender, EventArgs args) =>
+        // Re-initialize the theme when the system theme changes
+        InitializeTheme();
+
+    public void Dispose()
+    {
+        _eventRoot.Dispose();
+        _services.Dispose();
     }
 }

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -16,7 +16,6 @@ using YoutubeDownloader.ViewModels;
 using YoutubeDownloader.ViewModels.Components;
 using YoutubeDownloader.ViewModels.Dialogs;
 using YoutubeDownloader.Views;
-using ThemeVariant = Avalonia.Styling.ThemeVariant;
 
 namespace YoutubeDownloader;
 
@@ -64,9 +63,9 @@ public class App : Application, IDisposable
                 {
                     RequestedThemeVariant = _settingsService.Theme switch
                     {
-                        Framework.ThemeVariant.System => ThemeVariant.Default,
-                        Framework.ThemeVariant.Light => ThemeVariant.Light,
-                        Framework.ThemeVariant.Dark => ThemeVariant.Dark,
+                        ThemeVariant.System => Avalonia.Styling.ThemeVariant.Default,
+                        ThemeVariant.Light => Avalonia.Styling.ThemeVariant.Light,
+                        ThemeVariant.Dark => Avalonia.Styling.ThemeVariant.Dark,
                         _
                             => throw new InvalidOperationException(
                                 $"Unknown theme '{_settingsService.Theme}'."
@@ -99,18 +98,11 @@ public class App : Application, IDisposable
 
     private void InitializeTheme()
     {
-        var requestedTheme = RequestedThemeVariant ?? ThemeVariant.Default;
-
-        var actualTheme = requestedTheme.Key switch
+        var actualTheme = RequestedThemeVariant?.Key switch
         {
-            "Default" => PlatformSettings?.GetColorValues().ThemeVariant,
             "Light" => PlatformThemeVariant.Light,
             "Dark" => PlatformThemeVariant.Dark,
-            _
-                => throw new ArgumentOutOfRangeException(
-                    nameof(requestedTheme),
-                    $"Unknown theme '{requestedTheme}'."
-                )
+            _ => PlatformSettings?.GetColorValues().ThemeVariant
         };
 
         if (actualTheme == PlatformThemeVariant.Light)

--- a/YoutubeDownloader/Framework/ThemeVariant.cs
+++ b/YoutubeDownloader/Framework/ThemeVariant.cs
@@ -1,0 +1,8 @@
+﻿namespace YoutubeDownloader.Framework;
+
+public enum ThemeVariant
+{
+    System,
+    Light,
+    Dark
+}

--- a/YoutubeDownloader/Services/SettingsService.cs
+++ b/YoutubeDownloader/Services/SettingsService.cs
@@ -4,11 +4,10 @@ using System.IO;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Avalonia;
-using Avalonia.Platform;
 using Cogwheel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using YoutubeDownloader.Core.Downloading;
+using YoutubeDownloader.Framework;
 using Container = YoutubeExplode.Videos.Streams.Container;
 
 namespace YoutubeDownloader.Services;
@@ -21,10 +20,10 @@ public partial class SettingsService()
     private bool _isUkraineSupportMessageEnabled = true;
 
     [ObservableProperty]
-    private bool _isAutoUpdateEnabled = true;
+    private ThemeVariant _theme;
 
     [ObservableProperty]
-    private bool _isDarkModeEnabled;
+    private bool _isAutoUpdateEnabled = true;
 
     [ObservableProperty]
     private bool _isAuthPersisted = true;
@@ -53,17 +52,6 @@ public partial class SettingsService()
 
     [ObservableProperty]
     private VideoQualityPreference _lastVideoQualityPreference = VideoQualityPreference.Highest;
-
-    public override void Reset()
-    {
-        base.Reset();
-
-        // Reset the dark mode setting separately because its default value is evaluated dynamically
-        // and cannot be set by the field initializer.
-        IsDarkModeEnabled =
-            Application.Current?.PlatformSettings?.GetColorValues().ThemeVariant
-            == PlatformThemeVariant.Dark;
-    }
 
     public override void Save()
     {

--- a/YoutubeDownloader/Utils/Extensions/AvaloniaExtensions.cs
+++ b/YoutubeDownloader/Utils/Extensions/AvaloniaExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.VisualTree;
 

--- a/YoutubeDownloader/ViewModels/Dialogs/SettingsViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/SettingsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using YoutubeDownloader.Framework;
 using YoutubeDownloader.Services;
 using YoutubeDownloader.Utils;
@@ -19,16 +20,18 @@ public class SettingsViewModel : DialogViewModelBase
         _eventRoot.Add(_settingsService.WatchAllProperties(OnAllPropertiesChanged));
     }
 
+    public IReadOnlyList<ThemeVariant> AvailableThemes { get; } = Enum.GetValues<ThemeVariant>();
+
+    public ThemeVariant Theme
+    {
+        get => _settingsService.Theme;
+        set => _settingsService.Theme = value;
+    }
+
     public bool IsAutoUpdateEnabled
     {
         get => _settingsService.IsAutoUpdateEnabled;
         set => _settingsService.IsAutoUpdateEnabled = value;
-    }
-
-    public bool IsDarkModeEnabled
-    {
-        get => _settingsService.IsDarkModeEnabled;
-        set => _settingsService.IsDarkModeEnabled = value;
     }
 
     public bool IsAuthPersisted

--- a/YoutubeDownloader/ViewModels/MainViewModel.cs
+++ b/YoutubeDownloader/ViewModels/MainViewModel.cs
@@ -79,18 +79,6 @@ public partial class MainViewModel(
     [RelayCommand]
     private async Task InitializeAsync()
     {
-        // Reset settings (needed to resolve the default dark mode setting)
-        settingsService.Reset();
-
-        // Load settings
-        settingsService.Load();
-
-        // Set the correct theme
-        if (settingsService.IsDarkModeEnabled)
-            App.SetDarkTheme();
-        else
-            App.SetLightTheme();
-
         await ShowUkraineSupportMessageAsync();
         await CheckForUpdatesAsync();
     }

--- a/YoutubeDownloader/Views/Dialogs/SettingsView.axaml
+++ b/YoutubeDownloader/Views/Dialogs/SettingsView.axaml
@@ -23,6 +23,19 @@
             BorderThickness="0,1">
             <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                 <StackPanel Orientation="Vertical">
+                    <!--  Theme  -->
+                    <DockPanel
+                        Margin="16,8"
+                        LastChildFill="False"
+                        ToolTip.Tip="Preferred user interface theme">
+                        <TextBlock DockPanel.Dock="Left" Text="Theme" />
+                        <ComboBox
+                            Width="150"
+                            DockPanel.Dock="Right"
+                            ItemsSource="{Binding AvailableThemes}"
+                            SelectedItem="{Binding Theme}" />
+                    </DockPanel>
+
                     <!--  Auto-updates  -->
                     <DockPanel
                         Margin="16,8"
@@ -42,19 +55,6 @@
                         </ToolTip.Tip>
                         <TextBlock DockPanel.Dock="Left" Text="Auto-update" />
                         <ToggleSwitch DockPanel.Dock="Right" IsChecked="{Binding IsAutoUpdateEnabled}" />
-                    </DockPanel>
-
-                    <!--  Dark mode  -->
-                    <DockPanel
-                        Margin="16,8"
-                        LastChildFill="False"
-                        ToolTip.Tip="Use darker colors in the UI">
-                        <TextBlock DockPanel.Dock="Left" Text="Dark mode" />
-                        <ToggleSwitch
-                            x:Name="DarkModeToggleSwitch"
-                            DockPanel.Dock="Right"
-                            IsChecked="{Binding IsDarkModeEnabled}"
-                            IsCheckedChanged="DarkModeToggleSwitch_OnIsCheckedChanged" />
                     </DockPanel>
 
                     <!--  Persist authentication  -->

--- a/YoutubeDownloader/Views/Dialogs/SettingsView.axaml.cs
+++ b/YoutubeDownloader/Views/Dialogs/SettingsView.axaml.cs
@@ -1,4 +1,3 @@
-using Avalonia.Interactivity;
 using YoutubeDownloader.Framework;
 using YoutubeDownloader.ViewModels.Dialogs;
 
@@ -7,20 +6,4 @@ namespace YoutubeDownloader.Views.Dialogs;
 public partial class SettingsView : UserControl<SettingsViewModel>
 {
     public SettingsView() => InitializeComponent();
-
-    private void DarkModeToggleSwitch_OnIsCheckedChanged(object? sender, RoutedEventArgs args)
-    {
-        if (DarkModeToggleSwitch.IsChecked is true)
-        {
-            App.SetDarkTheme();
-        }
-        else if (DarkModeToggleSwitch.IsChecked is false)
-        {
-            App.SetLightTheme();
-        }
-        else
-        {
-            App.SetDefaultTheme();
-        }
-    }
 }

--- a/YoutubeDownloader/YoutubeDownloader.csproj
+++ b/YoutubeDownloader/YoutubeDownloader.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="DialogHost.Avalonia" Version="0.7.7" />
     <PackageReference Include="DotnetRuntimeBootstrapper" Version="2.5.4" PrivateAssets="all" />
     <PackageReference Include="Gress" Version="2.1.1" />
-    <PackageReference Include="Material.Avalonia" Version="3.5.0" />
-    <PackageReference Include="Material.Avalonia.DataGrid" Version="3.5.0" />
+    <PackageReference Include="Material.Avalonia" Version="3.6.0" />
+    <PackageReference Include="Material.Avalonia.DataGrid" Version="3.6.0" />
     <PackageReference Include="Material.Icons.Avalonia" Version="2.1.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Onova" Version="2.6.11" />


### PR DESCRIPTION
Previous: user can switch between light and dark mode, with the default setting inferred from system on the application's initial startup.

Current: user can switch between light and dark mode, as well as use the "system" variant. The latter stays in-sync with the current system settings after the initial startup, even if settings change mid-session.