### PR TITLE
Skip `WL` playlist on video URLs when not logged in

### DIFF
--- a/YoutubeDownloader.Core/Resolving/QueryResolver.cs
+++ b/YoutubeDownloader.Core/Resolving/QueryResolver.cs
@@ -30,9 +30,16 @@ public class QueryResolver(IReadOnlyList<Cookie>? initialCookies = null)
         // Playlist
         if (isUrl && PlaylistId.TryParse(query) is { } playlistId)
         {
-            var playlist = await _youtube.Playlists.GetAsync(playlistId, cancellationToken);
-            var videos = await _youtube.Playlists.GetVideosAsync(playlistId, cancellationToken);
-            return new QueryResult(QueryResultKind.Playlist, $"Playlist: {playlist.Title}", videos);
+            if (playlistId.Value is not "WL" || initialCookies is { Count: > 0 })
+            {
+                var playlist = await _youtube.Playlists.GetAsync(playlistId, cancellationToken);
+                var videos = await _youtube.Playlists.GetVideosAsync(playlistId, cancellationToken);
+                return new QueryResult(
+                    QueryResultKind.Playlist,
+                    $"Playlist: {playlist.Title}",
+                    videos
+                );
+            }
         }
 
         // Video


### PR DESCRIPTION
Closes #453 

do not get video by playlist when list is `WL`/`LL`/`LM` and no login info