### PR TITLE
Look for FFmpeg in both user-wide and system-wide `PATH` locations

### DIFF
--- a/YoutubeDownloader.Core/Downloading/FFmpeg.cs
+++ b/YoutubeDownloader.Core/Downloading/FFmpeg.cs
@@ -17,12 +17,17 @@ public static class FFmpeg
             yield return AppContext.BaseDirectory;
             yield return Directory.GetCurrentDirectory();
 
-            var UserAndMachineEnvironmentVariables =
-                $"{Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User)}{Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine)}";
-
-            if (UserAndMachineEnvironmentVariables?.Split(Path.PathSeparator) is { } paths)
+            // User PATH environment variable
+            if (Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User)?.Split(Path.PathSeparator) is { } userPaths)
             {
-                foreach (var path in paths)
+                foreach (var path in userPaths)
+                    yield return path;
+            }
+
+            // System PATH environment variable
+            if (Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine)?.Split(Path.PathSeparator) is { } systemPaths)
+            {
+                foreach (var path in systemPaths)
                     yield return path;
             }
         }

--- a/YoutubeDownloader.Core/Downloading/FFmpeg.cs
+++ b/YoutubeDownloader.Core/Downloading/FFmpeg.cs
@@ -17,7 +17,10 @@ public static class FFmpeg
             yield return AppContext.BaseDirectory;
             yield return Directory.GetCurrentDirectory();
 
-            if (Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) is { } paths)
+            var UserAndMachineEnvironmentVariables =
+                $"{Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User)}{Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine)}";
+
+            if (UserAndMachineEnvironmentVariables?.Split(Path.PathSeparator) is { } paths)
             {
                 foreach (var path in paths)
                     yield return path;


### PR DESCRIPTION
`Environment.GetEnvironmentVariable("PATH")`  gives you the effective PATH that the operating system uses when searching for executable files from `User PATH`.
Thus if some developers like me add `FFMPEG` path to system PATH they always face with that page which tells there is no `FFMPEG `installed or cannot be found.
I had changed codes to get the `PATH` from both the `System` and `User` environment variables.