### PR TITLE
Add Avalonia temporary build tasks to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # Build results
 bin/
 obj/
+
+# Avalonia
 .avalonia-build-tasks/
 
 # Test results

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Build results
 bin/
 obj/
+.avalonia-build-tasks/
 
 # Test results
 TestResults/


### PR DESCRIPTION
Ignore Avalonia Build tasks files in git so they are not mistakenly staged

Closes #648 

