### PR TITLE
Defer errors when processing multiple queries

### DIFF
--- a/YoutubeDownloader.Core/Resolving/QueryResolver.cs
+++ b/YoutubeDownloader.Core/Resolving/QueryResolver.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Gress;
 using YoutubeDownloader.Core.Utils;
 using YoutubeExplode;
 using YoutubeExplode.Channels;
@@ -121,34 +119,5 @@ public class QueryResolver(IReadOnlyList<Cookie>? initialCookies = null)
             ?? await TryResolveVideoAsync(query, cancellationToken)
             ?? await TryResolveChannelAsync(query, cancellationToken)
             ?? await ResolveSearchAsync(query, cancellationToken);
-    }
-
-    public async Task<QueryResult> ResolveAsync(
-        IReadOnlyList<string> queries,
-        IProgress<Percentage>? progress = null,
-        CancellationToken cancellationToken = default
-    )
-    {
-        if (queries.Count == 1)
-            return await ResolveAsync(queries.Single(), cancellationToken);
-
-        var videos = new List<IVideo>();
-        var videoIds = new HashSet<VideoId>();
-
-        var completed = 0;
-        foreach (var query in queries)
-        {
-            var result = await ResolveAsync(query, cancellationToken);
-
-            foreach (var video in result.Videos)
-            {
-                if (videoIds.Add(video.Id))
-                    videos.Add(video);
-            }
-
-            progress?.Report(Percentage.FromFraction(1.0 * ++completed / queries.Count));
-        }
-
-        return new QueryResult(QueryResultKind.Aggregate, $"{queries.Count} queries", videos);
     }
 }

--- a/YoutubeDownloader.Core/Resolving/QueryResult.cs
+++ b/YoutubeDownloader.Core/Resolving/QueryResult.cs
@@ -8,8 +8,15 @@ public record QueryResult(QueryResultKind Kind, string Title, IReadOnlyList<IVid
 {
     public static QueryResult Aggregate(IReadOnlyList<QueryResult> results) =>
         new(
-            results.Count == 1 ? results.Single().Kind : QueryResultKind.Aggregate,
-            results.Count == 1 ? results.Single().Title : $"{results.Count} Queries",
+            // Single query -> inherit kind, multiple queries -> aggregate
+            results.Count == 1
+                ? results.Single().Kind
+                : QueryResultKind.Aggregate,
+            // Single query -> inherit title, multiple queries -> aggregate
+            results.Count == 1
+                ? results.Single().Title
+                : $"{results.Count} queries",
+            // Combine all videos, deduplicate by ID
             results.SelectMany(q => q.Videos).DistinctBy(v => v.Id).ToArray()
         );
 }

--- a/YoutubeDownloader.Core/Resolving/QueryResult.cs
+++ b/YoutubeDownloader.Core/Resolving/QueryResult.cs
@@ -1,6 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using YoutubeExplode.Videos;
 
 namespace YoutubeDownloader.Core.Resolving;
 
-public record QueryResult(QueryResultKind Kind, string Title, IReadOnlyList<IVideo> Videos);
+public record QueryResult(QueryResultKind Kind, string Title, IReadOnlyList<IVideo> Videos)
+{
+    public static QueryResult Aggregate(IReadOnlyList<QueryResult> results) =>
+        new(
+            results.Count == 1 ? results.Single().Kind : QueryResultKind.Aggregate,
+            results.Count == 1 ? results.Single().Title : $"{results.Count} Queries",
+            results.SelectMany(q => q.Videos).DistinctBy(v => v.Id).ToArray()
+        );
+}

--- a/YoutubeDownloader.Core/Resolving/QueryResult.cs
+++ b/YoutubeDownloader.Core/Resolving/QueryResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using YoutubeExplode.Videos;
 
@@ -6,8 +7,12 @@ namespace YoutubeDownloader.Core.Resolving;
 
 public record QueryResult(QueryResultKind Kind, string Title, IReadOnlyList<IVideo> Videos)
 {
-    public static QueryResult Aggregate(IReadOnlyList<QueryResult> results) =>
-        new(
+    public static QueryResult Aggregate(IReadOnlyList<QueryResult> results)
+    {
+        if (!results.Any())
+            throw new ArgumentException("Cannot aggregate empty results.", nameof(results));
+
+        return new QueryResult(
             // Single query -> inherit kind, multiple queries -> aggregate
             results.Count == 1
                 ? results.Single().Kind
@@ -19,4 +24,5 @@ public record QueryResult(QueryResultKind Kind, string Title, IReadOnlyList<IVid
             // Combine all videos, deduplicate by ID
             results.SelectMany(q => q.Videos).DistinctBy(v => v.Id).ToArray()
         );
+    }
 }


### PR DESCRIPTION
Closes #563

Lets the user download videos, even if some (but not all) of the input queries failed