### PR TITLE
Fix vertical scrollbar visibility in download list

### DIFF
--- a/YoutubeDownloader/Views/Components/DashboardView.axaml
+++ b/YoutubeDownloader/Views/Components/DashboardView.axaml
@@ -137,7 +137,7 @@
                 HorizontalScrollBarVisibility="Disabled"
                 IsVisible="{Binding !!Downloads.Count}"
                 ItemsSource="{Binding Downloads}"
-                VerticalScrollBarVisibility="Auto">
+                VerticalScrollBarVisibility="Visible">
                 <DataGrid.ContextMenu>
                     <ContextMenu>
                         <MenuItem Command="{Binding RemoveSuccessfulDownloadsCommand}" Header="Remove successful downloads" />

--- a/YoutubeDownloader/YoutubeDownloader.csproj
+++ b/YoutubeDownloader/YoutubeDownloader.csproj
@@ -27,10 +27,10 @@
 
   <ItemGroup>
     <PackageReference Include="AsyncImageLoader.Avalonia" Version="3.3.0" />
-    <PackageReference Include="Avalonia" Version="11.2.6" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.6" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.6" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Avalonia" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.0" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Cogwheel" Version="2.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CSharpier.MsBuild" Version="0.30.6" PrivateAssets="all" />


### PR DESCRIPTION
Looks like a bug in Avalonia where setting `DataGrid.VerticalScrollBarVisibility` to `Visible` has the intended effect of `Auto`, whereas setting it to `Auto` has the intended effect of `Disabled`. Might need to undo this change with a future release of Avalonia which fixes this issue.

Closes #672 

