### PR TITLE
Add support for custom settings path

### DIFF
--- a/YoutubeDownloader/Services/SettingsService.cs
+++ b/YoutubeDownloader/Services/SettingsService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -15,10 +14,7 @@ namespace YoutubeDownloader.Services;
 
 [ObservableObject]
 public partial class SettingsService()
-    : SettingsBase(
-        Path.Combine(AppContext.BaseDirectory, "Settings.dat"),
-        SerializerContext.Default
-    )
+    : SettingsBase(StartOptions.Current.SettingsPath, SerializerContext.Default)
 {
     [ObservableProperty]
     public partial bool IsUkraineSupportMessageEnabled { get; set; } = true;

--- a/YoutubeDownloader/StartOptions.cs
+++ b/YoutubeDownloader/StartOptions.cs
@@ -44,21 +44,26 @@ public partial class StartOptions
     }
 
     private static bool TryMakeValidPath(
-        [NotNullWhen(true)] string? pathToDirectory,
+        string pathToDirectory,
         [NotNullWhen(true)] out string? result
     )
     {
-        result = null;
+        try
+        {
+            // Normalize the directory path and ensure it is a valid filesystem path.
+            var fullDirectoryPath = Path.GetFullPath(pathToDirectory);
 
-        if (pathToDirectory is null)
+            // Combine with the settings file name and normalize the full file path.
+            var pathToFile = Path.Combine(fullDirectoryPath, SettingsFileName);
+            var fullFilePath = Path.GetFullPath(pathToFile);
+            result = fullFilePath;
+            return true;
+        }
+        catch (Exception)
+        {
+            // Any exception indicates an invalid path.
+            result = null;
             return false;
-
-        var pathToFile = Path.Combine(pathToDirectory, SettingsFileName);
-
-        // Check if the path is a valid URI.
-        if (Uri.TryCreate(pathToFile, UriKind.RelativeOrAbsolute, out var uri))
-            result = uri.ToString();
-
-        return result is not null;
+        }
     }
 }

--- a/YoutubeDownloader/StartOptions.cs
+++ b/YoutubeDownloader/StartOptions.cs
@@ -14,7 +14,7 @@ public partial class StartOptions
 {
     private static readonly string SettingsFileName = "Settings.dat";
 
-    private static readonly string SettingsPathVariable = "SETTINGS_PATH";
+    private static readonly string SettingsPathVariable = "YOUTUBEDOWNLOADER_SETTINGS_DIR";
 
     private static readonly string DefaultSettingsPath = Path.Combine(
         AppContext.BaseDirectory,

--- a/YoutubeDownloader/StartOptions.cs
+++ b/YoutubeDownloader/StartOptions.cs
@@ -28,10 +28,11 @@ public partial class StartOptions
 
     private static string GetSettingsPath(IDictionary environmentVars)
     {
-        if (
-            !environmentVars.Contains(SettingsPathVariable)
-            || environmentVars[SettingsPathVariable] is not string pathFromEnv
-        )
+        if (!environmentVars.Contains(SettingsPathVariable))
+            return DefaultSettingsPath;
+
+        var pathFromEnv = environmentVars[SettingsPathVariable] as string;
+        if (string.IsNullOrWhiteSpace(pathFromEnv))
             return DefaultSettingsPath;
 
         // Check Environment Variables first.

--- a/YoutubeDownloader/StartOptions.cs
+++ b/YoutubeDownloader/StartOptions.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace YoutubeDownloader;
@@ -14,56 +12,22 @@ public partial class StartOptions
 {
     private static readonly string SettingsFileName = "Settings.dat";
 
-    private static readonly string SettingsPathVariable = "YOUTUBEDOWNLOADER_SETTINGS_DIR";
+    private static readonly string SettingsPathVariable = "YOUTUBEDOWNLOADER_SETTINGS_PATH";
 
     private static readonly string DefaultSettingsPath = Path.Combine(
         AppContext.BaseDirectory,
         SettingsFileName
     );
 
-    public static StartOptions Current { get; } = Parse(Environment.GetEnvironmentVariables());
-
-    private static StartOptions Parse(IDictionary environmentVars) =>
-        new() { SettingsPath = GetSettingsPath(environmentVars) };
-
-    private static string GetSettingsPath(IDictionary environmentVars)
-    {
-        if (!environmentVars.Contains(SettingsPathVariable))
-            return DefaultSettingsPath;
-
-        var pathFromEnv = environmentVars[SettingsPathVariable] as string;
-        if (string.IsNullOrWhiteSpace(pathFromEnv))
-            return DefaultSettingsPath;
-
-        // Check Environment Variables first.
-        if (TryMakeValidPath(pathFromEnv, out var result))
-            return result;
-
-        // Fall back to default path.
-        return DefaultSettingsPath;
-    }
-
-    private static bool TryMakeValidPath(
-        string pathToDirectory,
-        [NotNullWhen(true)] out string? result
-    )
-    {
-        try
+    public static StartOptions Current { get; } =
+        new()
         {
-            // Normalize the directory path and ensure it is a valid filesystem path.
-            var fullDirectoryPath = Path.GetFullPath(pathToDirectory);
-
-            // Combine with the settings file name and normalize the full file path.
-            var pathToFile = Path.Combine(fullDirectoryPath, SettingsFileName);
-            var fullFilePath = Path.GetFullPath(pathToFile);
-            result = fullFilePath;
-            return true;
-        }
-        catch (Exception)
-        {
-            // Any exception indicates an invalid path.
-            result = null;
-            return false;
-        }
-    }
+            SettingsPath = Environment.GetEnvironmentVariable(SettingsPathVariable)
+                is { } path
+                    and not ""
+                ? Path.EndsInDirectorySeparator(path) || Directory.Exists(path)
+                    ? Path.Combine(path, SettingsFileName)
+                    : path
+                : DefaultSettingsPath,
+        };
 }

--- a/YoutubeDownloader/StartOptions.cs
+++ b/YoutubeDownloader/StartOptions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace YoutubeDownloader;
+
+public partial class StartOptions
+{
+    public required string SettingsPath { get; init; }
+}
+
+public partial class StartOptions
+{
+    private static readonly string SettingsFileName = "Settings.dat";
+
+    private static readonly string SettingsPathVariable = "SETTINGS_PATH";
+
+    private static readonly string DefaultSettingsPath = Path.Combine(
+        AppContext.BaseDirectory,
+        SettingsFileName
+    );
+
+    public static StartOptions Current { get; } = Parse(Environment.GetEnvironmentVariables());
+
+    private static StartOptions Parse(IDictionary environmentVars) =>
+        new() { SettingsPath = GetSettingsPath(environmentVars) };
+
+    private static string GetSettingsPath(IDictionary environmentVars)
+    {
+        if (
+            !environmentVars.Contains(SettingsPathVariable)
+            || environmentVars[SettingsPathVariable] is not string pathFromEnv
+        )
+            return DefaultSettingsPath;
+
+        // Check Environment Variables first.
+        if (TryMakeValidPath(pathFromEnv, out var result))
+            return result;
+
+        // Fall back to default path.
+        return DefaultSettingsPath;
+    }
+
+    private static bool TryMakeValidPath(
+        [NotNullWhen(true)] string? pathToDirectory,
+        [NotNullWhen(true)] out string? result
+    )
+    {
+        result = null;
+
+        if (pathToDirectory is null)
+            return false;
+
+        var pathToFile = Path.Combine(pathToDirectory, SettingsFileName);
+
+        // Check if the path is a valid URI.
+        if (Uri.TryCreate(pathToFile, UriKind.RelativeOrAbsolute, out var uri))
+            result = uri.ToString();
+
+        return result is not null;
+    }
+}


### PR DESCRIPTION
To easily allow packaging the app in environments that don't allow modifications to the package directory (like NixOS), this PR adds the option to define a custom directory to store the settings in. The directory can be defined with an environment variable.

Proposed variable name is `SETTINGS_PATH`

This solution is using a similar approach to [Lightbulb](https://github.com/Tyrrrz/LightBulb/blob/master/LightBulb/StartOptions.cs)
