### PR TITLE
Fix a race condition that could prevent the app from persisting settings

### DIFF
--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -113,6 +113,10 @@ public class App : Application, IDisposable
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = new MainView { DataContext = _mainViewModel };
+
+            // App's `Dispose()` method may not be called on some systems,
+            // so we add this handlers as a fallback.
+            // https://github.com/Tyrrrz/YoutubeDownloader/issues/795
             desktop.Exit += Desktop_OnExit;
         }
 

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -126,7 +126,9 @@ public class App : Application, IDisposable
     private void Desktop_OnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
     {
         _mainViewModel.Dispose();
-        desktop.Exit -= Desktop_OnExit;
+
+        if (sender is IControlledApplicationLifetime lifetime)
+            lifetime.Exit -= Desktop_OnExit;
     }
 
     private void Application_OnActualThemeVariantChanged(object? sender, EventArgs args) =>

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -111,7 +111,7 @@ public class App : Application, IDisposable
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = new MainView { DataContext = _mainViewModel };
-            desktop.Exit += DesktopOnExit;
+            desktop.Exit += Desktop_OnExit;
         }
 
         base.OnFrameworkInitializationCompleted();
@@ -123,9 +123,10 @@ public class App : Application, IDisposable
         _settingsService.Load();
     }
 
-    private void DesktopOnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
+    private void Desktop_OnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
     {
         _mainViewModel.Dispose();
+        desktop.Exit -= Desktop_OnExit;
     }
 
     private void Application_OnActualThemeVariantChanged(object? sender, EventArgs args) =>

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -127,10 +127,10 @@ public class App : Application, IDisposable
 
     private void Desktop_OnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
     {
-        Dispose();
-
         if (sender is IControlledApplicationLifetime lifetime)
             lifetime.Exit -= Desktop_OnExit;
+
+        Dispose();
     }
 
     private void Application_OnActualThemeVariantChanged(object? sender, EventArgs args) =>

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -144,7 +144,7 @@ public class App : Application, IDisposable
 
         _isDisposed = true;
 
-_eventRoot.Dispose();
-_services.Dispose();
+				_eventRoot.Dispose();
+				_services.Dispose();
     }
 }

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -25,6 +25,7 @@ public class App : Application, IDisposable
 
     private readonly ServiceProvider _services;
     private readonly SettingsService _settingsService;
+    private readonly UpdateService _updateService;
     private readonly MainViewModel _mainViewModel;
 
     public App()
@@ -56,6 +57,7 @@ public class App : Application, IDisposable
 
         _services = services.BuildServiceProvider(true);
         _settingsService = _services.GetRequiredService<SettingsService>();
+        _updateService = _services.GetRequiredService<UpdateService>();
         _mainViewModel = _services.GetRequiredService<ViewModelManager>().CreateMainViewModel();
 
         // Re-initialize the theme when the user changes it
@@ -109,7 +111,10 @@ public class App : Application, IDisposable
     public override void OnFrameworkInitializationCompleted()
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
             desktop.MainWindow = new MainView { DataContext = _mainViewModel };
+            desktop.Exit += DesktopOnExit;
+        }
 
         base.OnFrameworkInitializationCompleted();
 
@@ -118,6 +123,15 @@ public class App : Application, IDisposable
 
         // Load settings
         _settingsService.Load();
+    }
+
+    private void DesktopOnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
+    {
+        // Save settings
+        _settingsService.Save();
+
+        // Finalize pending updates
+        _updateService.FinalizeUpdate(false);
     }
 
     private void Application_OnActualThemeVariantChanged(object? sender, EventArgs args) =>

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -27,6 +27,8 @@ public class App : Application, IDisposable
     private readonly SettingsService _settingsService;
     private readonly MainViewModel _mainViewModel;
 
+    private bool _isDisposed;
+
     public App()
     {
         var services = new ServiceCollection();
@@ -125,7 +127,7 @@ public class App : Application, IDisposable
 
     private void Desktop_OnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
     {
-        _mainViewModel.Dispose();
+        Dispose();
 
         if (sender is IControlledApplicationLifetime lifetime)
             lifetime.Exit -= Desktop_OnExit;
@@ -137,7 +139,12 @@ public class App : Application, IDisposable
 
     public void Dispose()
     {
+        if (_isDisposed)
+            return;
+
         _eventRoot.Dispose();
         _services.Dispose();
+
+        _isDisposed = true;
     }
 }

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -25,7 +25,6 @@ public class App : Application, IDisposable
 
     private readonly ServiceProvider _services;
     private readonly SettingsService _settingsService;
-    private readonly UpdateService _updateService;
     private readonly MainViewModel _mainViewModel;
 
     public App()
@@ -57,7 +56,6 @@ public class App : Application, IDisposable
 
         _services = services.BuildServiceProvider(true);
         _settingsService = _services.GetRequiredService<SettingsService>();
-        _updateService = _services.GetRequiredService<UpdateService>();
         _mainViewModel = _services.GetRequiredService<ViewModelManager>().CreateMainViewModel();
 
         // Re-initialize the theme when the user changes it
@@ -111,10 +109,7 @@ public class App : Application, IDisposable
     public override void OnFrameworkInitializationCompleted()
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
-        {
             desktop.MainWindow = new MainView { DataContext = _mainViewModel };
-            desktop.Exit += DesktopOnExit;
-        }
 
         base.OnFrameworkInitializationCompleted();
 
@@ -123,15 +118,6 @@ public class App : Application, IDisposable
 
         // Load settings
         _settingsService.Load();
-    }
-
-    private void DesktopOnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
-    {
-        // Save settings
-        _settingsService.Save();
-
-        // Finalize pending updates
-        _updateService.FinalizeUpdate(false);
     }
 
     private void Application_OnActualThemeVariantChanged(object? sender, EventArgs args) =>

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -142,9 +142,9 @@ public class App : Application, IDisposable
         if (_isDisposed)
             return;
 
-        _eventRoot.Dispose();
-        _services.Dispose();
-
         _isDisposed = true;
+
+_eventRoot.Dispose();
+_services.Dispose();
     }
 }

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -144,7 +144,7 @@ public class App : Application, IDisposable
 
         _isDisposed = true;
 
-				_eventRoot.Dispose();
-				_services.Dispose();
+        _eventRoot.Dispose();
+        _services.Dispose();
     }
 }

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -109,7 +109,10 @@ public class App : Application, IDisposable
     public override void OnFrameworkInitializationCompleted()
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
             desktop.MainWindow = new MainView { DataContext = _mainViewModel };
+            desktop.Exit += DesktopOnExit;
+        }
 
         base.OnFrameworkInitializationCompleted();
 
@@ -118,6 +121,11 @@ public class App : Application, IDisposable
 
         // Load settings
         _settingsService.Load();
+    }
+
+    private void DesktopOnExit(object? sender, ControlledApplicationLifetimeExitEventArgs e)
+    {
+        _mainViewModel.Dispose();
     }
 
     private void Application_OnActualThemeVariantChanged(object? sender, EventArgs args) =>

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -115,7 +115,7 @@ public class App : Application, IDisposable
             desktop.MainWindow = new MainView { DataContext = _mainViewModel };
 
             // App's `Dispose()` method may not be called on some systems,
-            // so we add this handlers as a fallback.
+            // so we add this handler as a fallback.
             // https://github.com/Tyrrrz/YoutubeDownloader/issues/795
             desktop.Exit += Desktop_OnExit;
         }

--- a/YoutubeDownloader/App.axaml.cs
+++ b/YoutubeDownloader/App.axaml.cs
@@ -114,8 +114,9 @@ public class App : Application, IDisposable
         {
             desktop.MainWindow = new MainView { DataContext = _mainViewModel };
 
-            // App's `Dispose()` method may not be called on some systems,
-            // so we add this handler as a fallback.
+            // Although `App.Dispose()` is invoked from `Program.Main(...)`, on some platforms
+            // it may be called too late in the shutdown lifecycle. Attach an exit
+            // handler to ensure timely disposal as a safeguard.
             // https://github.com/Tyrrrz/YoutubeDownloader/issues/795
             desktop.Exit += Desktop_OnExit;
         }

--- a/YoutubeDownloader/ViewModels/MainViewModel.cs
+++ b/YoutubeDownloader/ViewModels/MainViewModel.cs
@@ -162,4 +162,18 @@ public partial class MainViewModel(
         await ShowFFmpegMissingMessageAsync();
         await CheckForUpdatesAsync();
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Save settings
+            settingsService.Save();
+
+            // Finalize pending updates
+            updateService.FinalizeUpdate(false);
+        }
+
+        base.Dispose(disposing);
+    }
 }

--- a/YoutubeDownloader/ViewModels/MainViewModel.cs
+++ b/YoutubeDownloader/ViewModels/MainViewModel.cs
@@ -162,18 +162,4 @@ public partial class MainViewModel(
         await ShowFFmpegMissingMessageAsync();
         await CheckForUpdatesAsync();
     }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            // Save settings
-            settingsService.Save();
-
-            // Finalize pending updates
-            updateService.FinalizeUpdate(false);
-        }
-
-        base.Dispose(disposing);
-    }
 }


### PR DESCRIPTION
Moved the shutdown logic from `MainViewModel.Dispose()` to `IControlledApplicationLifetime.Exit` event handler.

This makes sure the save logic is executed reliably.
Out of my ~20 test runs no exception was thrown and changes persisted as expected.
<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #795 

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
