### PR TITLE
Fix double-dispose, use-after-dispose, and FFmpeg binary planting

### DIFF
--- a/YoutubeDownloader.Core/Downloading/FFmpeg.cs
+++ b/YoutubeDownloader.Core/Downloading/FFmpeg.cs
@@ -22,7 +22,6 @@ public static class FFmpeg
     public static IEnumerable<string> GetProbeDirectoryPaths()
     {
         yield return AppContext.BaseDirectory;
-        yield return Directory.GetCurrentDirectory();
 
         // Process PATH
         if (

--- a/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
@@ -387,19 +387,18 @@ public partial class DashboardViewModel : ViewModelBase
     private void RestartDownload(DownloadViewModel download)
     {
         var position = Math.Max(0, Downloads.IndexOf(download));
+
+        // Copy properties before disposing the original download
+        var video = download.Video!;
+        var filePath = download.FilePath!;
+        var downloadOption = download.DownloadOption;
+        var downloadPreference = download.DownloadPreference;
+
         RemoveDownload(download);
 
-        var newDownload = download.DownloadOption is not null
-            ? _viewModelManager.GetDownloadViewModel(
-                download.Video!,
-                download.DownloadOption,
-                download.FilePath!
-            )
-            : _viewModelManager.GetDownloadViewModel(
-                download.Video!,
-                download.DownloadPreference!,
-                download.FilePath!
-            );
+        var newDownload = downloadOption is not null
+            ? _viewModelManager.GetDownloadViewModel(video, downloadOption, filePath)
+            : _viewModelManager.GetDownloadViewModel(video, downloadPreference!, filePath);
 
         EnqueueDownload(newDownload, position);
     }

--- a/YoutubeDownloader/ViewModels/Components/DownloadViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Components/DownloadViewModel.cs
@@ -147,10 +147,13 @@ public partial class DownloadViewModel : ViewModelBase
     {
         if (disposing)
         {
-            _eventSubscription.Dispose();
-            _cancellationTokenSource.Dispose();
+            if (_isDisposed)
+                return;
 
             _isDisposed = true;
+
+            _eventSubscription.Dispose();
+            _cancellationTokenSource.Dispose();
         }
 
         base.Dispose(disposing);


### PR DESCRIPTION
## Summary

This PR addresses three bugs found during a code audit — two runtime correctness issues and one security hardening fix.

---

### 1. Double-dispose guard in `DownloadViewModel.Dispose()`

**Problem:** When a user removes an in-flight download, `RemoveDownload()` calls both `CancelCommand.ExecuteIfCan()` and `download.Dispose()`. The cancellation propagates to `EnqueueDownload`'s `finally` block, which also calls `download.Dispose()`. This results in `_cancellationTokenSource.Dispose()` and `_eventSubscription.Dispose()` being called twice, risking an `ObjectDisposedException`.

The existing `_isDisposed` flag was set **after** disposing resources, so it could not protect against re-entrant disposal.

**Fix:** Check `_isDisposed` at the top of the `Dispose(bool)` method and set the flag **before** disposing resources. This is the standard dispose guard pattern recommended by Microsoft.

**File:** `YoutubeDownloader/ViewModels/Components/DownloadViewModel.cs`

---

### 2. Use-after-dispose in `RestartDownload()`

**Problem:** `RestartDownload()` calls `RemoveDownload(download)` which disposes the `DownloadViewModel`, and then reads `download.Video`, `download.FilePath`, `download.DownloadOption`, and `download.DownloadPreference` from the already-disposed object. While the properties are currently simple auto-properties (so reads happen to work), this is semantically incorrect and will break silently if the implementation ever changes (e.g., adding disposal logic to property accessors or nullifying fields on dispose).

**Fix:** Copy all needed properties into local variables **before** calling `RemoveDownload()`.

**File:** `YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs`

---

### 3. Remove `Directory.GetCurrentDirectory()` from FFmpeg probe paths (binary planting)

**Problem:** `FFmpeg.GetProbeDirectoryPaths()` yields `Directory.GetCurrentDirectory()` as the **second** search location, before the system `PATH`. If the application is launched from a directory containing a malicious `ffmpeg` binary (e.g., a Downloads folder, a shared network drive, or a temp directory), that binary will be picked up and executed with the user's privileges.

This is a well-known attack vector called [binary planting / CWD hijacking](https://cwe.mitre.org/data/definitions/427.html) (CWE-427). It is particularly relevant for GUI apps, since the working directory often depends on how the OS launches the process (shortcut properties, file associations, etc.) and is not under the application's control.

**Fix:** Remove `Directory.GetCurrentDirectory()` from the probe path list. `AppContext.BaseDirectory` (the app's own installation directory) remains as the first probe location, followed by `PATH`. This matches the behavior of well-hardened applications that avoid CWD-based binary resolution.

**File:** `YoutubeDownloader.Core/Downloading/FFmpeg.cs`

---

## Test plan

- [ ] Start a download, cancel it mid-progress, then remove it from the list — verify no crash or unhandled exception in debug output
- [ ] Start a download, let it fail (e.g., invalid URL), then click restart — verify the download restarts correctly with the same video/quality/path
- [ ] Place a dummy `ffmpeg` executable in the working directory, launch the app from that directory — verify it is **not** picked up (the app should use the one in its own directory or from PATH)
- [ ] Verify FFmpeg auto-download still works when no FFmpeg is found on the system