### PR TITLE
Change how the Simplified Chinese language is displayed

### DIFF
--- a/YoutubeDownloader/Converters/EnumDisplayConverter.cs
+++ b/YoutubeDownloader/Converters/EnumDisplayConverter.cs
@@ -1,29 +1,28 @@
 using System;
-using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Reflection;
 using Avalonia.Data.Converters;
-using YoutubeDownloader.Localization;
 
 namespace YoutubeDownloader.Converters;
 
-public class LanguageToStringConverter : IValueConverter
+public class EnumDisplayConverter : IValueConverter
 {
-    public static LanguageToStringConverter Instance { get; } = new();
+    public static EnumDisplayConverter Instance { get; } = new();
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is Language language)
+        if (value is Enum enumValue)
         {
-            var memberInfo = typeof(Language).GetMember(language.ToString());
+            var memberInfo = enumValue.GetType().GetMember(enumValue.ToString());
             if (memberInfo.Length > 0)
             {
-                var descAttr = memberInfo[0].GetCustomAttribute<DescriptionAttribute>();
-                if (descAttr is not null)
-                    return descAttr.Description;
+                var displayAttr = memberInfo[0].GetCustomAttribute<DisplayAttribute>();
+                if (displayAttr?.Name is not null)
+                    return displayAttr.Name;
             }
 
-            return language.ToString();
+            return enumValue.ToString();
         }
 
         return default(string);

--- a/YoutubeDownloader/Converters/LanguageToStringConverter.cs
+++ b/YoutubeDownloader/Converters/LanguageToStringConverter.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+using Avalonia.Data.Converters;
+using YoutubeDownloader.Localization;
+
+namespace YoutubeDownloader.Converters;
+
+public class LanguageToStringConverter : IValueConverter
+{
+    public static LanguageToStringConverter Instance { get; } = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is Language language)
+        {
+            var memberInfo = typeof(Language).GetMember(language.ToString());
+            if (memberInfo.Length > 0)
+            {
+                var descAttr = memberInfo[0].GetCustomAttribute<DescriptionAttribute>();
+                if (descAttr is not null)
+                    return descAttr.Description;
+            }
+
+            return language.ToString();
+        }
+
+        return default(string);
+    }
+
+    public object ConvertBack(
+        object? value,
+        Type targetType,
+        object? parameter,
+        CultureInfo culture
+    ) => throw new NotSupportedException();
+}

--- a/YoutubeDownloader/Localization/Language.cs
+++ b/YoutubeDownloader/Localization/Language.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace YoutubeDownloader.Localization;
 
 public enum Language
@@ -8,5 +10,7 @@ public enum Language
     German,
     French,
     Spanish,
+
+    [Description("Simplified Chinese")]
     ChineseSimplified,
 }

--- a/YoutubeDownloader/Localization/Language.cs
+++ b/YoutubeDownloader/Localization/Language.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace YoutubeDownloader.Localization;
 
@@ -11,6 +11,6 @@ public enum Language
     French,
     Spanish,
 
-    [Description("Simplified Chinese")]
+    [Display(Name = "Simplified Chinese")]
     ChineseSimplified,
 }

--- a/YoutubeDownloader/Views/Dialogs/SettingsView.axaml
+++ b/YoutubeDownloader/Views/Dialogs/SettingsView.axaml
@@ -48,7 +48,7 @@
                             SelectedItem="{Binding Language}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
-                                    <TextBlock Text="{Binding Converter={x:Static converters:LanguageToStringConverter.Instance}}" />
+                                    <TextBlock Text="{Binding Converter={x:Static converters:EnumDisplayConverter.Instance}}" />
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>

--- a/YoutubeDownloader/Views/Dialogs/SettingsView.axaml
+++ b/YoutubeDownloader/Views/Dialogs/SettingsView.axaml
@@ -29,7 +29,7 @@
                         ToolTip.Tip="{Binding LocalizationManager.ThemeTooltip}">
                         <TextBlock DockPanel.Dock="Left" Text="{Binding LocalizationManager.ThemeLabel}" />
                         <ComboBox
-                            Width="150"
+                            Width="160"
                             DockPanel.Dock="Right"
                             ItemsSource="{Binding AvailableThemes}"
                             SelectedItem="{Binding Theme}" />
@@ -42,10 +42,16 @@
                         ToolTip.Tip="{Binding LocalizationManager.LanguageTooltip}">
                         <TextBlock DockPanel.Dock="Left" Text="{Binding LocalizationManager.LanguageLabel}" />
                         <ComboBox
-                            Width="150"
+                            Width="160"
                             DockPanel.Dock="Right"
                             ItemsSource="{Binding AvailableLanguages}"
-                            SelectedItem="{Binding Language}" />
+                            SelectedItem="{Binding Language}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={x:Static converters:LanguageToStringConverter.Instance}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                     </DockPanel>
 
                     <!--  Auto-updates  -->


### PR DESCRIPTION
#819 That PR cannot implement this feature.
If you want to use `Chinese(Simplified)` - it's better to just change the `Description` in `Language.cs`. That will do it.