### PR TITLE
Harden login URL match

### DIFF
--- a/YoutubeDownloader/Views/Dialogs/AuthSetupView.axaml.cs
+++ b/YoutubeDownloader/Views/Dialogs/AuthSetupView.axaml.cs
@@ -64,11 +64,12 @@ public partial class AuthSetupView : UserControl<AuthSetupViewModel>
 
         // Extract the cookies after being redirected to the home page (i.e. after logging in)
         if (
-            args.Url?.AbsoluteUri.StartsWith(HomePageUrl, StringComparison.OrdinalIgnoreCase)
-            == true
+            Uri.TryCreate(args.Url?.AbsoluteUri, UriKind.Absolute, out var navUri)
+            && navUri.Scheme == Uri.UriSchemeHttps
+            && string.Equals(navUri.Host, "www.youtube.com", StringComparison.OrdinalIgnoreCase)
         )
         {
-            var cookies = await _coreWebView2!.CookieManager.GetCookiesAsync(args.Url.AbsoluteUri);
+            var cookies = await _coreWebView2!.CookieManager.GetCookiesAsync(navUri.AbsoluteUri);
             DataContext.Cookies = cookies.Select(c => c.ToSystemNetCookie()).ToArray();
         }
     }

--- a/YoutubeDownloader/Views/Dialogs/AuthSetupView.axaml.cs
+++ b/YoutubeDownloader/Views/Dialogs/AuthSetupView.axaml.cs
@@ -64,12 +64,12 @@ public partial class AuthSetupView : UserControl<AuthSetupViewModel>
 
         // Extract the cookies after being redirected to the home page (i.e. after logging in)
         if (
-            Uri.TryCreate(args.Url?.AbsoluteUri, UriKind.Absolute, out var navUri)
-            && navUri.Scheme == Uri.UriSchemeHttps
-            && string.Equals(navUri.Host, "www.youtube.com", StringComparison.OrdinalIgnoreCase)
+            args.Url is { } url
+            && url.Scheme == Uri.UriSchemeHttps
+            && string.Equals(url.Host, "www.youtube.com", StringComparison.OrdinalIgnoreCase)
         )
         {
-            var cookies = await _coreWebView2!.CookieManager.GetCookiesAsync(navUri.AbsoluteUri);
+            var cookies = await _coreWebView2!.CookieManager.GetCookiesAsync(url.AbsoluteUri);
             DataContext.Cookies = cookies.Select(c => c.ToSystemNetCookie()).ToArray();
         }
     }


### PR DESCRIPTION
Implements the two hardening items from #825.

## Changes

### `SettingsService.AuthCookiesEncryptionConverter`
- `Key` is now `Lazy<byte[]?>` and returns `null` when `Environment.TryGetMachineId()` returns `null` or whitespace.
- `Read` and `Write` check for that and skip the encryption path: cookies stay in memory for the current session but are not persisted under a deterministic key derived from an empty input.

### `AuthSetupView.WebBrowser_OnNavigationStarting`
- Replaced the `args.Url.AbsoluteUri.StartsWith("https://www.youtube.com", ...)` prefix match with a parsed `Uri` check requiring `Scheme == https` and `Host == www.youtube.com` (case-insensitive). This avoids the `www.youtube.comX` and `www.youtube.com.attacker.example` lookalikes covered in the issue.

## Notes
- No behavior change for the common case (Windows registry `MachineGuid` set, or Linux `/etc/machine-id` set, or macOS `Environment.MachineName`).
- No additional dependencies.
- `dotnet build -c Release` clean, 0 warnings.
- The repo has no test project, so no regression tests are included; happy to add a small `xunit` project alongside if that's wanted.

Closes #825