### PR TITLE
Avoid touching target files before downloads finish

### DIFF
--- a/YoutubeDownloader/Utils/Extensions/PathExtensions.cs
+++ b/YoutubeDownloader/Utils/Extensions/PathExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace YoutubeDownloader.Utils.Extensions;
@@ -6,9 +8,13 @@ internal static class PathExtensions
 {
     extension(Path)
     {
-        public static string EnsureUniqueFilePath(string baseFilePath, int maxRetries = 100)
+        public static string EnsureUniqueFilePath(
+            string baseFilePath,
+            ISet<string>? reservedFilePaths = null,
+            int maxRetries = 100
+        )
         {
-            if (!File.Exists(baseFilePath))
+            if (!File.Exists(baseFilePath) && reservedFilePaths?.Contains(baseFilePath) != true)
                 return baseFilePath;
 
             var baseDirPath = Path.GetDirectoryName(baseFilePath);
@@ -22,11 +28,13 @@ internal static class PathExtensions
                     ? Path.Combine(baseDirPath, fileName)
                     : fileName;
 
-                if (!File.Exists(filePath))
+                if (!File.Exists(filePath) && reservedFilePaths?.Contains(filePath) != true)
                     return filePath;
             }
 
-            return baseFilePath;
+            throw new InvalidOperationException(
+                $"Could not find a unique file path for '{baseFilePath}'."
+            );
         }
     }
 }

--- a/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
@@ -151,10 +151,24 @@ public partial class DashboardViewModel : ViewModelBase
     private async Task ShowSettingsAsync() =>
         await _dialogManager.ShowDialogAsync(_viewModelManager.GetSettingsViewModel());
 
+    private static string GetTempDownloadFilePath(string filePath)
+    {
+        var dirPath = Path.GetDirectoryName(filePath);
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
+        var extension = Path.GetExtension(filePath);
+        var tempFileName = $".{fileNameWithoutExtension}.{Guid.NewGuid():N}{extension}";
+
+        return !string.IsNullOrWhiteSpace(dirPath)
+            ? Path.Combine(dirPath, tempFileName)
+            : tempFileName;
+    }
+
     private async void EnqueueDownload(DownloadViewModel download, int position = 0)
     {
         Downloads.Insert(position, download);
         var progress = _progressMuxer.CreateInput();
+        var filePath = download.FilePath!;
+        var tempFilePath = GetTempDownloadFilePath(filePath);
 
         try
         {
@@ -175,7 +189,7 @@ public partial class DashboardViewModel : ViewModelBase
                 );
 
             await downloader.DownloadVideoAsync(
-                download.FilePath!,
+                tempFilePath,
                 download.Video!,
                 downloadOption,
                 _settingsService.ShouldInjectSubtitles,
@@ -189,7 +203,7 @@ public partial class DashboardViewModel : ViewModelBase
                 try
                 {
                     await tagInjector.InjectTagsAsync(
-                        download.FilePath!,
+                        tempFilePath,
                         download.Video!,
                         download.CancellationToken
                     );
@@ -200,6 +214,8 @@ public partial class DashboardViewModel : ViewModelBase
                 }
             }
 
+            File.Move(tempFilePath, filePath, true);
+
             download.Status = DownloadStatus.Completed;
         }
         catch (Exception ex)
@@ -207,8 +223,8 @@ public partial class DashboardViewModel : ViewModelBase
             try
             {
                 // Delete the incompletely downloaded file
-                if (!string.IsNullOrWhiteSpace(download.FilePath))
-                    File.Delete(download.FilePath);
+                if (File.Exists(tempFilePath))
+                    File.Delete(tempFilePath);
             }
             catch
             {

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
@@ -77,6 +77,10 @@ public partial class DownloadMultipleSetupViewModel(
             return;
 
         var downloads = new List<DownloadViewModel>();
+        var reservedFilePaths = new HashSet<string>(
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal
+        );
+
         foreach (var (i, video) in SelectedVideos.Index())
         {
             var baseFilePath = Path.Combine(
@@ -92,11 +96,8 @@ public partial class DownloadMultipleSetupViewModel(
             if (settingsService.ShouldSkipExistingFiles && File.Exists(baseFilePath))
                 continue;
 
-            var filePath = Path.EnsureUniqueFilePath(baseFilePath);
-
-            // Download does not start immediately, so lock in the file path to avoid conflicts
-            Directory.CreateForFile(filePath);
-            await File.WriteAllBytesAsync(filePath, []);
+            var filePath = Path.EnsureUniqueFilePath(baseFilePath, reservedFilePaths);
+            reservedFilePaths.Add(filePath);
 
             downloads.Add(
                 viewModelManager.GetDownloadViewModel(

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadSingleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadSingleSetupViewModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
@@ -7,7 +6,6 @@ using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using PowerKit.Extensions;
 using YoutubeDownloader.Core.Downloading;
 using YoutubeDownloader.Framework;
 using YoutubeDownloader.Localization;
@@ -72,10 +70,6 @@ public partial class DownloadSingleSetupViewModel(
 
         if (string.IsNullOrWhiteSpace(filePath))
             return;
-
-        // Download does not start immediately, so lock in the file path to avoid conflicts
-        Directory.CreateForFile(filePath);
-        await File.WriteAllBytesAsync(filePath, []);
 
         settingsService.LastContainer = container;
 


### PR DESCRIPTION
This avoids touching the final output file until the download has actually finished.

Right now the dialogs create an empty file up front to reserve the path, which can overwrite an existing file and then delete it if the download fails or gets canceled. This changes that to download into a temp file first, then move it into place at the end.

Checked with `dotnet build YoutubeDownloader.slnx`.
