### PR TITLE
Stop after FFmpeg auto-download failure

### DIFF
--- a/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
@@ -129,6 +129,9 @@ public partial class DashboardViewModel : ViewModelBase
                     ex.Message
                 )
             );
+
+            if (Application.Current?.ApplicationLifetime?.TryShutdown(3) != true)
+                Environment.Exit(3);
         }
         finally
         {

--- a/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Components/DashboardViewModel.cs
@@ -128,8 +128,7 @@ public partial class DashboardViewModel : ViewModelBase
                 )
             );
 
-            if (Application.Current?.ApplicationLifetime?.TryShutdown(3) != true)
-                Environment.Exit(3);
+            App.Shutdown(3);
         }
         finally
         {


### PR DESCRIPTION
This closes the app if the automatic FFmpeg download fails.

If FFmpeg is missing and the user chooses not to download it, the app already exits. This makes the failed-download case behave the same way instead of leaving the app open in a state where downloads will still fail.

Checked with `dotnet build YoutubeDownloader.slnx`.
