### PR TITLE
Fix reservation and auth edge cases

### DIFF
--- a/YoutubeDownloader/ViewModels/Dialogs/AuthSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/AuthSetupViewModel.cs
@@ -48,7 +48,7 @@ public class AuthSetupViewModel : DialogViewModelBase
                 ?.Where(c => c.Name.StartsWith("__SECURE", StringComparison.OrdinalIgnoreCase))
                 .ToArray();
 
-            // None of the '__SECURE' cookies should be expired.
+            // At least one '__SECURE' cookie must exist and none of them should be expired
             return secureCookies?.Any() == true
                 && secureCookies.All(c =>
                     !c.Expired && c.Expires.ToUniversalTime() > DateTime.UtcNow

--- a/YoutubeDownloader/ViewModels/Dialogs/AuthSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/AuthSetupViewModel.cs
@@ -40,13 +40,21 @@ public class AuthSetupViewModel : DialogViewModelBase
         set => _settingsService.LastAuthCookies = value;
     }
 
-    public bool IsAuthenticated =>
-        Cookies?.Any() == true
-        &&
-        // None of the '__SECURE' cookies should be expired
-        Cookies
-            .Where(c => c.Name.StartsWith("__SECURE", StringComparison.OrdinalIgnoreCase))
-            .All(c => !c.Expired && c.Expires.ToUniversalTime() > DateTime.UtcNow);
+    public bool IsAuthenticated
+    {
+        get
+        {
+            var secureCookies = Cookies
+                ?.Where(c => c.Name.StartsWith("__SECURE", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            // None of the '__SECURE' cookies should be expired.
+            return secureCookies?.Any() == true
+                && secureCookies.All(c =>
+                    !c.Expired && c.Expires.ToUniversalTime() > DateTime.UtcNow
+                );
+        }
+    }
 
     protected override void Dispose(bool disposing)
     {

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
@@ -96,9 +96,13 @@ public partial class DownloadMultipleSetupViewModel(
             if (
                 settingsService.ShouldSkipExistingFiles
                 && File.Exists(baseFilePath)
+                // Don't skip if the existing file is a file created for another download in
+                // the same batch (i.e. two different videos with the same output file name).
                 && !reservedFilePaths.Contains(baseFilePath)
             )
+            {
                 continue;
+            }
 
             var filePath = Path.EnsureUniqueFilePath(baseFilePath);
 

--- a/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
+++ b/YoutubeDownloader/ViewModels/Dialogs/DownloadMultipleSetupViewModel.cs
@@ -77,6 +77,10 @@ public partial class DownloadMultipleSetupViewModel(
             return;
 
         var downloads = new List<DownloadViewModel>();
+        var reservedFilePaths = new HashSet<string>(
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal
+        );
+
         foreach (var (i, video) in SelectedVideos.Index())
         {
             var baseFilePath = Path.Combine(
@@ -89,7 +93,11 @@ public partial class DownloadMultipleSetupViewModel(
                 )
             );
 
-            if (settingsService.ShouldSkipExistingFiles && File.Exists(baseFilePath))
+            if (
+                settingsService.ShouldSkipExistingFiles
+                && File.Exists(baseFilePath)
+                && !reservedFilePaths.Contains(baseFilePath)
+            )
                 continue;
 
             var filePath = Path.EnsureUniqueFilePath(baseFilePath);
@@ -97,6 +105,7 @@ public partial class DownloadMultipleSetupViewModel(
             // Download does not start immediately, so lock in the file path to avoid conflicts
             Directory.CreateForFile(filePath);
             await File.WriteAllBytesAsync(filePath, []);
+            reservedFilePaths.Add(filePath);
 
             downloads.Add(
                 viewModelManager.GetDownloadViewModel(


### PR DESCRIPTION
Fixes two small edge cases from #839 and #840.

Changes:
- keep track of filenames reserved during the current multi-download setup, so `Skip existing files` does not skip duplicate-title videos that should instead get a unique filename
- require at least one `__SECURE` YouTube cookie before the auth dialog treats the user as signed in

Verification:
- `dotnet build YoutubeDownloader.slnx --nologo` succeeds with 0 warnings and 0 errors
- `git diff --check` passes
- reproduced the filename reservation issue with the same control flow before making the change